### PR TITLE
Feature/try rpath 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rblpapi
 Title: R Interface to BBG
-Version: 0.2.2.2
-Date: 2015-05-03
+Version: 0.2.2.3
+Date: 2015-05-04
 Maintainer: Whit Armstrong <armstrong.whit@gmail.com>
 Author: Whit Armstrong, Dirk Eddelbuettel, and John Laing
 Imports: Rcpp (>= 0.11.0)

--- a/cleanup
+++ b/cleanup
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-rm -f src/*.o src/Rblpapi.so src/Makevars
+rm -f src/*.o src/Rblpapi.{so,dylib} src/Makevars inst/blp/*.{so,dylib}

--- a/configure
+++ b/configure
@@ -7,18 +7,24 @@ if [ "${uname}" = "" ]; then
     exit -1
 fi
 
-## should also test for BBG header and library
+rpath=$(Rscript -e 'cat(file.path(.libPaths()[1], "Rblpapi", "blp"))')
 
 arch=$(uname -m)
 if [ "${arch}" = "x86_64" ]; then
     echo "Setting up compilation for 64-bit system"
-    sed -e's/@config@/blpapi3_64/' src/Makevars.in > src/Makevars
+    sed -e"s/@config@/blpapi3_32/" -e"s|@rpath@|"${rpath}"|" src/Makevars.in > src/Makevars
+    flavour="64"
 elif [ "${arch}" = "i686" ]; then
     echo "Setting up compilation for 32-bit system"
-    sed -e's/@config@/blpapi3_32/' src/Makevars.in > src/Makevars
+    sed -e"s/@config@/blpapi3_32/" -e"s|@rpath@|"${rpath}"|" src/Makevars.in > src/Makevars
+    flavour="32"
 else 
     echo "Unknown architecture: ${arch}. Exiting."
     exit -1
 fi
-   
+
+## unpack shared library from tarball
+cd inst/blp/
+tar xfz blpLinux.tar.gz libblpapi3_${flavour}.so
+
 exit 0

--- a/configure
+++ b/configure
@@ -12,7 +12,7 @@ rpath=$(Rscript -e 'cat(file.path(.libPaths()[1], "Rblpapi", "blp"))')
 arch=$(uname -m)
 if [ "${arch}" = "x86_64" ]; then
     echo "Setting up compilation for 64-bit system"
-    sed -e"s/@config@/blpapi3_32/" -e"s|@rpath@|"${rpath}"|" src/Makevars.in > src/Makevars
+    sed -e"s/@config@/blpapi3_64/" -e"s|@rpath@|"${rpath}"|" src/Makevars.in > src/Makevars
     flavour="64"
 elif [ "${arch}" = "i686" ]; then
     echo "Setting up compilation for 32-bit system"

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -5,8 +5,11 @@ CXX_STD      = CXX11
 
 ## filled in by configure
 BBG_LIB     = @config@
+BBG_RPATH   = @rpath@
 
 ## set include and linker options
 ## Bbg API files are assummed to be in the standard search path
 PKG_CPPFLAGS = -I../inst/include/ -I.
-PKG_LIBS    = -l$(BBG_LIB)
+PKG_LIBS     = -l$(BBG_LIB) -L../inst/blp/ -Wl,-rpath,$(BBG_RPATH)
+
+


### PR DESCRIPTION
This address part of the discussion in #33 and I have tested it on 32 and 64 bit Linux. In both cases the system-wide `libblpapi_*.so` was first removed / hidden / renamed.

So the package is now self-contained.  

This is still in a branch, and I recommend you first check it while keeping the branch.  Let's discuss if we want to keep things this way -- but at least it provides a neat little existence proof.